### PR TITLE
Update docker-compose.yml to use image from ghcr

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -33,7 +33,7 @@ services:
   # this service can be a separate file, remember to
   # leave networks declaration in both of those
   ddb-proxy:
-    build: .
+    image: ghcr.io/mrprimate/ddb-proxy:latest
     environment:
       - VIRTUAL_HOST=ddb-proxy.example.com
       - VIRTUAL_PORT=3000


### PR DESCRIPTION
This PR changes sample docker-compose.yml so that it pulls latest image from container registry instead of building own image.