### PR TITLE
add multiarch build

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Prepare
       id: prep
       run: |
-        DOCKER_IMAGE=${{ env.REGISTRY }}/${{ github.actor }}/${GITHUB_REPOSITORY#*/}
+        DOCKER_IMAGE=$(echo ${{ env.REGISTRY }}/${{ github.actor }}/${GITHUB_REPOSITORY#*/} | tr '[:upper:]' '[:lower:]')
         VERSION=latest
         SHORTREF=${GITHUB_SHA::8}
 

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -17,9 +17,29 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
 
-    - id: get-repo
-      name: Get Docker Image Identifiers
-      run: echo "::set-output name=IMAGE_REPOSITORY::$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]')"
+    - name: Prepare
+      id: prep
+      run: |
+        DOCKER_IMAGE=${{ env.REGISTRY }}/${{ github.actor }}/${GITHUB_REPOSITORY#*/}
+        VERSION=latest
+        SHORTREF=${GITHUB_SHA::8}
+
+        # If this is git tag, use the tag name as a docker tag
+        if [[ $GITHUB_REF == refs/tags/* ]]; then
+          VERSION=${GITHUB_REF#refs/tags/v}
+        fi
+        TAGS="${DOCKER_IMAGE}:${VERSION},${DOCKER_IMAGE}:${SHORTREF}"
+
+        # If the VERSION looks like a version number, assume that
+        # this is the most recent version of the image and also
+        # tag it 'latest'.
+        if [[ $VERSION =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
+          TAGS="$TAGS,${DOCKER_IMAGE}:latest"
+        fi
+
+        # Set output parameters.
+        echo ::set-output name=tags::${TAGS}
+        echo ::set-output name=docker_image::${DOCKER_IMAGE}
 
     - name: Log in to the Container registry
       uses: docker/login-action@v1
@@ -28,10 +48,22 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@master
+      with:
+        platforms: all
+
+    - name: Set up Docker Buildx
+      id: buildx
+      uses: docker/setup-buildx-action@master
+    
     - name: Build & Push the Docker image
       uses: docker/build-push-action@v2
       with:
         context: docker
+        builder: ${{ steps.buildx.outputs.name }}
         target: ${{ env.TARGET }}
         push: true
-        tags: '${{ env.REGISTRY }}/${{ steps.get-repo.outputs.IMAGE_REPOSITORY }}'
+        platforms: linux/amd64,linux/arm64,linux/arm
+        tags: ${{ steps.prep.outputs.tags }}
+        


### PR DESCRIPTION
I started using foundry on Oracle Cloud ampere server which uses arm64 architecture. This patch implements builds for most common architectures (amd64, arm, arm64) so it should be running without issues on all popular architectures.

Side note: I had some issues with publishing to github packages, but it should be working now. If this fails to push new container to ghcr repository after PR is merged, please let me know.